### PR TITLE
fix: Fix import v-markdown package

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,9 @@
   },
   "dependencies": {
     "markdown-it": "^8.4.0"
-  }
+  },
+  "files": [
+    "src"
+  ],
+  "main": "src/index.js"
 }


### PR DESCRIPTION
The folder paths where the files are located are added, in addition to the main file to be used when importing this package.

fix #3